### PR TITLE
Add "hcl append" command for adding additional notes to currently running timer.

### DIFF
--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -98,6 +98,15 @@ module HCl
       end
     end
 
+    def append notes = nil
+      entry = DayEntry.last
+      if entry && entry.running?
+        entry.append_note "\n\n#{notes}" unless notes.nil?
+      else
+        puts "No timer currently running."
+      end
+    end
+
   private
     def current_time
       Time.now.strftime('%I:%M %p').downcase


### PR DESCRIPTION
Have a long-running timer for a long-running task that you want to keep a running log of notes for?  Let me introduce you to `hcl append`.

Fire off `hcl append "Your new note."` and it'll tack on a new paragraph (_i.e._, after two `\n`) to your notes field for your currently running timer.

Inspired by @wycats feature request at dinner last night.
