### PR TITLE
Fix uninitialized constant HCl::TimesheetResource::CGI (NameError)

### DIFF
--- a/lib/hcl/timesheet_resource.rb
+++ b/lib/hcl/timesheet_resource.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'net/https'
+require 'cgi'
 
 module HCl
   class TimesheetResource


### PR DESCRIPTION
Was missing cgi and failed with error: uninitialized constant HCl::TimesheetResource::CGI (NameError) with ruby 1.9.3
