### PR TITLE
Fix `hcl status` 

### DIFF
--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -15,8 +15,12 @@ module HCl
       result = Faraday.new("http://kccljmymlslr.statuspage.io/api/v2") do |f|
         f.adapter Faraday.default_adapter
       end.get('status.json').body
-      date = Time.at(result[:last_check_time].to_i)
-      "Harvest is #{result[:status]}, response time: #{result[:last_response_time]}ms. [#{date}]"
+
+      json = Yajl::Parser.parse result, symbolize_keys: true
+      status = json[:status][:description]
+      updated_at = DateTime.parse(json[:page][:updated_at]).strftime "%F %T %:z"
+
+      "#{status} [#{updated_at}]"
     end
 
     def console

--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -13,7 +13,6 @@ module HCl
     # Show the network status of the Harvest service.
     def status
       result = Faraday.new("http://kccljmymlslr.statuspage.io/api/v2") do |f|
-        f.use :harvest, '', ''
         f.adapter Faraday.default_adapter
       end.get('status.json').body
       date = Time.at(result[:last_check_time].to_i)

--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -12,7 +12,7 @@ module HCl
 
     # Show the network status of the Harvest service.
     def status
-      result = Faraday.new("http://harveststatus.com/") do |f|
+      result = Faraday.new("http://kccljmymlslr.statuspage.io/api/v2") do |f|
         f.use :harvest, '', ''
         f.adapter Faraday.default_adapter
       end.get('status.json').body


### PR DESCRIPTION
Update the API enpoint we use to check the status, parse and output the response. Fixes #59.

@zenhob : I left out exception handling because I thought it wouldn't add much value, do you think it's needed? E.g. JSON parsing errors, connection problems, etc.