### PR TITLE
Multiple gemfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-language: ruby
-rvm:
-  - 2.0.0
-  - 2.1.6
-  - 2.2.2
-  - rbx-2.5.3
+matrix:
+  include:
+    - rvm: 2.0.0
+      gemfile: Gemfile
+    - rvm: 2.1.6
+      gemfile: Gemfile
+    - rvm: 2.2.2
+      gemfile: Gemfile
+    - rvm: rbx-2.5.3
+      gemfile: gemfiles/Gemfile.rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,10 @@
 source "https://rubygems.org"
 gemspec
-gem 'ronn', group:['development']
-# XXX this is dumb but it's crazy hard to get platform specfic deps into a gemspec
-gem 'byebug', group:['test','development'], platform:'ruby_20'
-gem 'rubysl-abbrev', platform:'rbx'
-gem 'rubysl-singleton', platform:'rbx'
-gem 'rubysl-rexml', platform:'rbx'
-gem 'rubysl-coverage', platform:'rbx', group:'test'
-gem 'rubinius-coverage', platform:'rbx', group:'test'
-gem 'yajl-ruby', platform:'rbx', group:'test'
+
+group :development do
+  gem 'ronn'
+end
+
+group :test, :development do
+  gem 'byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,12 +52,7 @@ GEM
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)
       rdiscount (>= 1.5.8)
-    rubinius-coverage (2.0.3)
     rubygems-tasks (0.2.4)
-    rubysl-abbrev (2.0.4)
-    rubysl-coverage (2.0.3)
-    rubysl-rexml (2.0.4)
-    rubysl-singleton (2.0.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -81,14 +76,8 @@ DEPENDENCIES
   mocha
   rake
   ronn
-  rubinius-coverage
   rubygems-tasks
-  rubysl-abbrev
-  rubysl-coverage
-  rubysl-rexml
-  rubysl-singleton
   simplecov
-  yajl-ruby
   yard
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,4 +81,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.10.2
+   1.10.3

--- a/gemfiles/Gemfile.rbx
+++ b/gemfiles/Gemfile.rbx
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gemspec path: '../hcl.gemspec'
+gemspec path: '../hcl'
 
 gem 'rubysl-abbrev'
 gem 'rubysl-singleton'

--- a/gemfiles/Gemfile.rbx
+++ b/gemfiles/Gemfile.rbx
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gemspec path: '../hcl'
+gemspec path: '..'
 
 gem 'rubysl-abbrev'
 gem 'rubysl-singleton'

--- a/gemfiles/Gemfile.rbx
+++ b/gemfiles/Gemfile.rbx
@@ -1,0 +1,16 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'rubysl-abbrev'
+gem 'rubysl-singleton'
+gem 'rubysl-rexml'
+
+group :development do
+  gem 'ronn'
+end
+
+group :test do
+  gem 'rubysl-coverage'
+  gem 'rubinius-coverage'
+  gem 'yajl-ruby'
+end

--- a/gemfiles/Gemfile.rbx
+++ b/gemfiles/Gemfile.rbx
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gemspec
+gemspec path: '../hcl.gemspec'
 
 gem 'rubysl-abbrev'
 gem 'rubysl-singleton'


### PR DESCRIPTION
Splits gemfiles based on platform, and uses a Travis [build matrix](http://docs.travis-ci.com/user/build-configuration/) to select the correct one.

MRI (v2+) users will keep on doing a simple `bundle install`. Rubinius users will have to pass the `--gemfile` parameter to bundle, like so: `bundle install --gemfile=gemfiles/Gemfile.rbx`.

We could easily add a Gemfile for MRI 1.9.

@zenhob what do you think about this approach?

Closes #62.