### PR TITLE
Adding Extensive Bas Tab Completion

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -124,15 +124,12 @@ The above starts and immediately stops a one-hour timer with the given note.
 
 ## ADVANCED USAGE
 
-### Bash Auto-completion of Task Aliases
+### Bash Tab Completions
 
-You can enable auto-completion of task aliases by adding this to your shell
-configuration (note the backticks inside the double quotes):
+You can enable auto-completion of commands, project ids, task ids and task aliases by adding this to your shell
+configuration:
 
-    complete -W "`cat ~/.hcl/aliases`" hcl
-
-Warning: You will need to have run `hcl` at least once to create the aliases
-file. Without it, this command will fail with an error.
+    source _hcl_completions
 
 ### Configuration Profiles
 
@@ -143,10 +140,9 @@ once, specify an alternate configuration directory in the environment as
 once.
 
 Here is a shell alias `myhcl` with a separate configuration from the
-main `hcl` command, and another command to configure alias completion:
+main `hcl` command, tab completion will work with the alias automatically:
 
     alias myhcl="env HCL_DIR=~/.myhcl hcl"
-    complete -W "`cat ~/.myhcl/aliases`" myhcl
 
 Adding something like the above to your bashrc will enable a new command,
 `myhcl`. When using `myhcl` you can use different credentials and aliases,

--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ The above starts and immediately stops a one-hour timer with the given note.
 You can enable auto-completion of commands, project ids, task ids and task aliases by adding this to your shell
 configuration:
 
-    source _hcl_completions
+    source $(ruby -e "print File.dirname(Gem.bin_path('hcl', 'hcl'))")/_hcl_completions
 
 ### Configuration Profiles
 

--- a/README.markdown
+++ b/README.markdown
@@ -140,9 +140,10 @@ once, specify an alternate configuration directory in the environment as
 once.
 
 Here is a shell alias `myhcl` with a separate configuration from the
-main `hcl` command, tab completion will work with the alias automatically:
+main `hcl` command, and another command to configure alias completion:
 
     alias myhcl="env HCL_DIR=~/.myhcl hcl"
+    complete -F _hcl myhcl
 
 Adding something like the above to your bashrc will enable a new command,
 `myhcl`. When using `myhcl` you can use different credentials and aliases,

--- a/bin/_hcl_completions
+++ b/bin/_hcl_completions
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+_hcl_getProjects()
+{
+    $1 tasks | perl -ne 's/ - (?!.* -).*//g; print;' | sed -e 's/\s[0-9]\+\s/ /g' | sed -e 's/\s/ /g' | sort | uniq
+}
+
+_hcl_getTasks()
+{
+    $1 tasks | grep "^$2" | sed -e 's/\s/ /g' | sort | uniq | cut -d" " -f 2-
+}
+
+_hcl()
+{
+    local count=${#COMP_WORDS[@]}
+    local script=${COMP_WORDS[0]}
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    case $count in
+        2)
+            COMPREPLY=( $(compgen -W "start resume log stop note show tasks alias unalias aliases cancel nvm oops config status" -- $cur) )
+            ;;
+        3)
+            local namespace=${COMP_WORDS[1]}
+            
+            case $namespace in
+                'alias')
+                    COMPREPLY=( $(compgen -W "" -- $cur) )
+                ;;
+                'start'|'resume'|'log')
+                    COMPREPLY=( $(compgen -W "$($script aliases | sed -e 's/,//g')" -- $cur) )
+                ;;
+            esac
+            ;;
+        4)
+            local namespace=${COMP_WORDS[1]}
+            local task=${COMP_WORDS[2]}
+            case $namespace in
+                'alias')
+                    local IFS_OLD="$IFS";
+                    local IFS=$'\n';
+                    COMPREPLY=( $(compgen -W "$(_hcl_getProjects $script)" -- $cur) )
+                    local IFS=$IFS_OLD;
+                    if [[ ${#COMPREPLY[*]} -eq 1 ]]; then #Only one completion
+                        COMPREPLY=$(echo $COMPREPLY | sed -e 's/\s.*$//g')
+                    fi
+                ;;
+            esac
+            ;;
+        5)
+            local namespace=${COMP_WORDS[1]}
+            local task=${COMP_WORDS[2]}
+            local projectid=${COMP_WORDS[3]}
+            case $namespace in
+                'alias')
+                    local IFS_OLD="$IFS";
+                    local IFS=$'\n';
+                    COMPREPLY=( $(compgen -W "$(_hcl_getTasks $script $projectid)" -- $cur) )
+                    local IFS=$IFS_OLD;
+                    if [[ ${#COMPREPLY[*]} -eq 1 ]]; then #Only one completion
+                        COMPREPLY=$(echo $COMPREPLY | sed -e 's/\s.*$//g')
+                    fi
+                ;;
+            esac
+            ;;
+    esac 
+}
+complete -F _hcl hcl

--- a/hcl.gemspec
+++ b/hcl.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email = "zack@zackhobson.com"
   s.description = "HCl is a command-line client for manipulating Harvest time sheets."
   s.executables = ["hcl"]
-  s.files = %w[LICENSE Rakefile Gemfile bin/hcl man/hcl.1] + Dir['*.markdown'] +
+  s.files = %w[LICENSE Rakefile Gemfile bin/hcl bin/_hcl_completions man/hcl.1] + Dir['*.markdown'] +
     Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
   s.homepage = "https://zenhob.github.io/hcl/"
   s.licenses = ["MIT"]


### PR DESCRIPTION
Tab completion will now use the calling script to generate suggestions.
Because of this those suggestions will work with the alias scheme
described in the README file.

These completion functions will also suggest the commands hcl allows.

When the alias command is in use it will complete the project ids and
task ids with descriptions.

The other commands that use aliases will complete them as before however
they used the calling script to get the list of aliases.  That way the
any bash alises using env's will be called and preserve the
configuration.  This will allow the user to only add one line to their
bashrc/profile w/e and not a line for each  bash alias the user may
need.
