### PR TITLE
Adding Git Style Messages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task :clean do
 end
 
 require 'rake/testtask'
+ENV['EDITOR'] = ''
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/*_test.rb']

--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -1,5 +1,6 @@
 require 'chronic'
 require 'highline'
+require 'tempfile'
 
 module HCl
   module Commands
@@ -111,9 +112,24 @@ module HCl
       if task.nil?
         fail "Unknown task alias, try one of the following: ", aliases.join(', ')
       end
+      note = args.join(' ')
+      if note == ''
+        m = Tempfile.new("message_temp")
+        m.write(args.join(' '))
+        m.close
+        if ENV['EDITOR'] == ''
+          ENV['EDITOR'] = 'touch'
+        end
+        system("$EDITOR #{m.path}")
+        m.open
+        m.rewind
+        note = m.read
+        m.close
+        m.unlink
+      end
       timer = task.start http,
         :starting_time => starting_time,
-        :note => args.join(' ')
+        :note => note
       "Started timer for #{timer} (at #{current_time})"
     end
 
@@ -126,7 +142,28 @@ module HCl
     def stop *args
       entry = DayEntry.with_timer(http) || DayEntry.with_timer(http, Date.today - 1)
       if entry
-        entry.append_note(http, args.join(' ')) if args.any?
+        note = args.join(' ')
+        set_note = ''
+        if note == ''
+          set_note = entry.notes
+          m = Tempfile.new("message_temp")
+          m.write(set_note)
+          m.close
+          if ENV['EDITOR'] == ''
+            ENV['EDITOR'] = 'touch'
+          end
+          system("$EDITOR #{m.path}")
+          m.open
+          m.rewind
+          set_note = m.read
+          m.close
+          m.unlink
+        end
+        if set_note != ''
+          entry.set_note(http, set_note)
+        elsif note != ''
+          entry.append_note(http, note)
+        end
         entry.toggle http
         "Stopped #{entry} (at #{current_time})"
       else
@@ -140,7 +177,24 @@ module HCl
         if args.empty?
           return entry.notes
         else
-          entry.append_note http, args.join(' ')
+          note = args.join(' ')
+          if note == ''
+            m = Tempfile.new("message_temp")
+            m.write(args.join(' '))
+            m.close
+            m.rewind
+            if ENV['EDITOR'] == ''
+              ENV['EDITOR'] = 'touch'
+            end
+            system("$EDITOR #{m.path}")
+            m.open
+            note = m.read
+            m.close
+            m.unlink
+          end
+          if note != ''
+            entry.append_note(http, note)
+          end
           "Added note to #{entry}."
         end
       else

--- a/lib/hcl/day_entry.rb
+++ b/lib/hcl/day_entry.rb
@@ -35,6 +35,13 @@ module HCl
       (self.notes << "\n#{new_notes}").lstrip!
       http.post "daily/update/#{id}", notes:notes, hours:hours
     end
+    
+    def set_note http, new_notes
+      # If I don't include hours it gets reset.
+      # This doens't appear to be the case for task and project.
+      @data[:notes] = new_notes
+      http.post "daily/update/#{id}", notes:notes, hours:hours
+    end
 
     def self.with_timer http, date=nil
       daily(http, date).detect {|t| t.running? }

--- a/test/day_entry_test.rb
+++ b/test/day_entry_test.rb
@@ -52,6 +52,13 @@ class DayEntryTest < HCl::TestCase
     entry.append_note(http, 'hi world')
     assert_equal "yourmom.\nhi world", entry.notes
   end
+  
+  def test_set_note
+    entry = HCl::DayEntry.new(:id => '1', :notes => 'yourmom.', :hours => '1.0')
+    http.stubs(:post)
+    entry.set_note(http, 'hi world')
+    assert_equal "hi world", entry.notes
+  end
 
   def test_append_note_to_empty
     entry = HCl::DayEntry.new(:id => '1', :notes => nil, :hours => '1.0')


### PR DESCRIPTION
Like git when a command that can take a note as an argument does not 
contain a note as an argument the user is prompted with their default editor to add
or edit the existing note depending on the command used.

If start is used the note is defaulted to blank if left blank no note is
set.

If stop the existing note is used to populate the editor.  Changes to
this note will overwrite the existing note, not append.

If a note is included in either start or stop the command behave as normal appending the note
argument to the entry.