### PR TITLE
Show all available notes when running show command

### DIFF
--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -155,7 +155,7 @@ module HCl
       DayEntry.daily(http, date).each do |day|
         running = day.running? ? '(running) ' : ''
         columns = HighLine::SystemExtensions.terminal_size[0] rescue 80
-        result << "\t#{day.formatted_hours}\t#{running}#{day.project}: #{day.notes.lines.to_a.last}\n"[0..columns-1]
+        result << "\t#{day.formatted_hours}\t#{running}#{day.project}: #{day.notes}\n"[0..columns-1]
         total_hours = total_hours + day.hours.to_f
       end
       result << ("\t" + '-' * 13) << "\n"

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -55,12 +55,12 @@ class CommandTest < HCl::TestCase
   def test_show
     HCl::DayEntry.expects(:daily).returns([HCl::DayEntry.new({
       hours:'2.06',
-      notes: 'hi world',
+      notes: "hi world\nhello again",
       project: 'App'
     })])
     result = show
     assert_equal \
-      "\t2:03\tApp: hi world\n\t-------------\n\t2:03\ttotal (as of high noon)\n",
+      "\t2:03\tApp: hi world\nhello again\n\t-------------\n\t2:03\ttotal (as of high noon)\n",
       result
   end
 


### PR DESCRIPTION
This will allow you to see all notes instead of just the last one. This is helpful if you weren't sure if you had already written a note earlier.
