### PR TITLE
Clarify the meaning of 'subdomain' when asking for it in the config prompt

### DIFF
--- a/lib/hcl/app.rb
+++ b/lib/hcl/app.rb
@@ -168,7 +168,7 @@ EOM
       puts "Please specify your Harvest credentials.\n"
       config['login'] = ask("Email Address: ").to_s
       config['password'] = ask("Password: ") { |q| q.echo = false }.to_s
-      config['subdomain'] = ask("Subdomain: ").to_s
+      config['subdomain'] = ask("Subdomain (acme in acme.harvestapp.com): ").to_s
       @http = HCl::Net.new config
       write_config config
     end


### PR DESCRIPTION
The first time I saw it, I wasn't sure what format of subdomain this
prompt wanted, and entered `acme.harvestapp.com`. Since it's not
documented in the README either, I had to source-dive to find the
answer. This clarifies what should be entered here by including an
example in the prompt.