### PR TITLE
App#save_password: Shell escape password

### DIFF
--- a/lib/hcl/app.rb
+++ b/lib/hcl/app.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'fileutils'
+require 'shellwords'
 
 require 'trollop'
 require 'highline/import'
@@ -226,10 +227,10 @@ EOM
     end
 
     def save_password config
-      if system("security add-internet-password -U -l hcl -a '%s' -s '%s.harvestapp.com' -w '%s'" % [
+      if system("security add-internet-password -U -l hcl -a '%s' -s '%s.harvestapp.com' -w %s" % [
         config['login'],
         config['subdomain'],
-        config['password'],
+        Shellwords.escape(config['password']),
       ]) then config.delete('password') end
     end
   end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -65,4 +65,17 @@ class AppTest < HCl::TestCase
     assert_match /API failure/i, error_output
   end
 
+  def test_save_password_allows_passwords_with_quotes
+    app = HCl::App.new
+    app.expects(:system).with("security add-internet-password -U -l hcl -a 'taco@example.com' -s 'acme.harvestapp.com' -w pass\\ with\\ \\'\\ quote")
+
+    config = {
+      'login' => 'taco@example.com',
+      'subdomain' => 'acme',
+      'password' => "pass with ' quote",
+    }
+
+    app.send :save_password, config
+  end
+
 end


### PR DESCRIPTION
Escape special shell characters so that passwords with single quotes can
be saved to the keychain. Otherwise, the single quotes surrounding the
"-w '%s'" cause an error on passwords with single quotes.

I know testing private methods is not recommended, but this seemed like
something that would be good to test. Maybe the method should be made
public if that's a concern?