### PR TITLE
Update commands.rb

### DIFF
--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -12,7 +12,7 @@ module HCl
 
     # Show the network status of the Harvest service.
     def status
-      result = Faraday.new("http://kccljmymlslr.statuspage.io/api/v2") do |f|
+      result = Faraday.new("https://kccljmymlslr.statuspage.io/api/v2") do |f|
         f.adapter Faraday.default_adapter
       end.get('status.json').body
 


### PR DESCRIPTION
Status page is nowadays https - plus it fixes the error when you try `hcl status`.